### PR TITLE
Fix: "Failed to retrieve real time from API, falling back to local time"

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -124,7 +124,7 @@ end
 --- @return number - Unix time
 local function retrieveTimeFromApi(callback)
     Citizen.CreateThread(function()
-        PerformHttpRequest("http://worldtimeapi.org/api/ip", function(statusCode, response)
+        PerformHttpRequest("https://worldtimeapi.org/api/ip", function(statusCode, response)
             if statusCode == 200 then
                 local data = json.decode(response)
                 if data == nil or data.unixtime == nil then


### PR DESCRIPTION
Replaced http with https inside of retrieveTimeFromApi function.

**Describe Pull request**
This is to fix the error: "Failed to retrieve real time from API, falling back to local time"

https://github.com/qbcore-framework/qb-weathersync/issues/83

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes.
- Does your code fit the style guidelines? Yes.
- Does your PR fit the contribution guidelines? Yes.
